### PR TITLE
Use new block based approach to consent form

### DIFF
--- a/packages/python/port/script.py
+++ b/packages/python/port/script.py
@@ -916,35 +916,35 @@ def prompt_consent(data, meta_data, locale, platform="Instagram"):
             )
             table_list.append(table)
 
+    blocks = [
+            props.PropsUIPromptConsentFormTable(
+                table.id,
+                table.title,
+                table.description,
+                table.data_frame,
+            )
+            for table in table_list
+        ]
     # Create donation buttons
-    donation_question = props.Translatable(
-        {
-            "en": f"Do you want to donate the above {platform_names.get(platform, platform)} data?",
-            "de": f"Möchten Sie die obigen {platform_names.get(platform, platform)}-Daten spenden?",
-            "nl": f"Wilt u de bovenstaande {platform_names.get(platform, platform)} gegevens doneren?",
-        }
+    blocks.append(
+        props.PropsUIDataSubmissionButtons(
+                    donate_question=props.Translatable(
+                         {
+                            "en": f"Do you want to donate the above {platform_names.get(platform, platform)} data?",
+                            "de": f"Möchten Sie die obigen {platform_names.get(platform, platform)}-Daten spenden?",
+                            "nl": f"Wilt u de bovenstaande {platform_names.get(platform, platform)} gegevens doneren?",
+                        }
+                    ),
+                    donate_button=props.Translatable(
+                        {
+                            "en": "Yes, donate",
+                            "de": "Ja, spenden",
+                            "nl": "Ja, doneren",
+                        }
+                    ),
+                ),
     )
-
-    donate_button = props.Translatable(
-        {
-            "en": "Yes, donate",
-            "de": "Ja, spenden",
-            "nl": "Ja, doneren",
-        }
-    )
-
-    return props.PropsUIPromptConsentForm(
-        table_list,
-        props.Translatable(
-            {
-                "en": f"Please review the extracted {platform_names.get(platform, platform)} data below before donating.",
-                "de": f"Bitte überprüfen Sie die extrahierten {platform_names.get(platform, platform)}-Daten unten, bevor Sie spenden.",
-                "nl": f"Bekijk de geëxtraheerde {platform_names.get(platform, platform)} gegevens hieronder voordat u doneert.",
-            }
-        ),
-        donation_question,
-        donate_button,
-    )
+    return blocks
 
 
 # pass on user decision to donate or decline donation


### PR DESCRIPTION
Feldspar has changed to a block based approach for the donation tables. This allows for more flexibility (it is now possible to also show other blocks between tables). This version works on my machine. There is one issue: the header text is missing. This requires a fix in the Feldspar code so that it can be included again.